### PR TITLE
 look up users by codename + Update props + admin protections

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -31,6 +31,10 @@ const UserSchema = new Schema({
   codeName: {
     type: String,
     unique: true
+  },
+  isAdmin: {
+    type: Boolean,
+    default: false
   }
 });
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -56,7 +56,7 @@ router.post('/admin/props', function(req, res, next) {
   });
 });
 
-/* GET NEW prop form. */
+/* GET EDIT prop form. */
 router.get('/admin/props/:id/edit', function(req, res, next) {
   Proposition.findById(req.params.id, function(err, prop) {
     if (err) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,7 +10,6 @@ router.use(function(req, res, next) {
   res.locals.title = "Voter's Guide";
   // so we can check if user is logged in
   res.locals.user = req.session.user;
-
   next();
 });
 
@@ -20,7 +19,9 @@ router.get('/', function(req, res, next) {
     if (err) {
       console.error(err);
     } else {
-      res.render('index', { props: props });
+      res.render('index', {
+        props: props
+      });
     }
   })
 });
@@ -31,7 +32,9 @@ router.get('/admin', function(req, res, next) {
     if (err) {
       console.error(err);
     } else {
-      res.render('admin', { props: props });
+      res.render('admin', {
+        props: props
+      });
     }
   })
 
@@ -44,11 +47,8 @@ router.get('/admin/props/new', function(req, res, next) {
 
 // POST/CREATE NEW prop
 router.post('/admin/props', function(req, res, next) {
-
-
   let prop = new Proposition(req.body);
-
-  prop.save(function(err, event) {
+  prop.save(function(err, Prop) {
     if (err) {
       console.error(err)
     };
@@ -56,4 +56,40 @@ router.post('/admin/props', function(req, res, next) {
   });
 });
 
+/* GET NEW prop form. */
+router.get('/admin/props/:id/edit', function(req, res, next) {
+  Proposition.findById(req.params.id, function(err, prop) {
+    if (err) {
+      console.error(err)
+    };
+    res.render('props/edit', {
+      prop: prop
+    });
+  });
+});
+
+// PUT/EDIT prop
+router.post('/admin/props/:id', function(req, res, next) {
+  //findByIdAndUpdate
+  //update with request object.body
+  let updatedProp = new Proposition(req.body);
+
+  Proposition.findByIdAndUpdate(
+    req.params.id, {
+      $set: {
+        name: updatedProp.name,
+        summary: updatedProp.summary,
+        pros: updatedProp.pros,
+        cons: updatedProp.cons,
+        readMoreUrl: updatedProp.readMoreUrl,
+        area: updatedProp.area
+      }
+    },
+    function(err, prop) {
+      if (err) {
+        console.error(err)
+      };
+      res.redirect('/admin');
+    });
+});
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,7 +1,41 @@
 const express = require('express');
 const router = express.Router();
 const User = require('../models/user');
+const Proposition = require('../models/proposition');
 const auth = require('./helpers/auth');
+
+/* SHOW Users votes. */
+router.get('/friend/:codeName', function(req, res, next) {
+  console.log(req.params);
+  User.findOne({
+      codeName: req.params.codeName
+    })
+    .exec(function(err, userWithCodeName) {
+      if (err) {
+        return next(err)
+      } else if (userWithCodeName) {
+        console.log(userWithCodeName);
+        Proposition.find({}, function(err, props) {
+          if (err) {
+            console.error(err);
+          } else {
+            res.render('index', {
+              props: props,
+              user: userWithCodeName
+            });
+          }
+        })
+      } else if (!userWithCodeName) {
+        Proposition.find({}, function(err, props) {
+          if (err) {
+            console.error(err);
+          } else {
+            res.send('No user goes by: ' + req.params.codeName);
+          }
+        })
+      }
+    });
+});
 
 // GET signup
 router.get('/signup', (req, res, next) => {
@@ -64,7 +98,7 @@ router.post('/save-vote', auth.requireLogin, function(req, res, next) {
           arrayOfNoVotes: req.body.yesVote
         }
       },
-      function(err, event) {
+      function(err, vote) {
         if (err) {
           console.error(err)
         };
@@ -83,7 +117,7 @@ router.post('/save-vote', auth.requireLogin, function(req, res, next) {
           arrayOfYesVotes: req.body.noVote
         }
       },
-      function(err, event) {
+      function(err, vote) {
         if (err) {
           console.error(err)
         };
@@ -99,7 +133,7 @@ router.post('/save-vote', auth.requireLogin, function(req, res, next) {
           arrayOfNoVotes: req.body.undoYesVote
         }
       },
-      function(err, event) {
+      function(err, vote) {
         if (err) {
           console.error(err)
         };
@@ -114,7 +148,7 @@ router.post('/save-vote', auth.requireLogin, function(req, res, next) {
           arrayOfNoVotes: req.body.undoNoVote
         }
       },
-      function(err, event) {
+      function(err, vote) {
         if (err) {
           console.error(err)
         };

--- a/views/admin.hbs
+++ b/views/admin.hbs
@@ -3,7 +3,7 @@
 {{#each props as |prop|}}
     <ul>
         <li>
-            {{prop.name}} (<a href="">Edit</a>)
+            {{prop.name}} (<a href="/admin/props/{{prop._id}}/edit/">Edit</a>)
         </li>
     </ul>
 {{/each}}

--- a/views/admin.hbs
+++ b/views/admin.hbs
@@ -1,9 +1,16 @@
 <h1>Admin Dashboard</h1>
-<a href="admin/props/new">Create new Proposition</a>
-{{#each props as |prop|}}
-    <ul>
-        <li>
-            {{prop.name}} (<a href="/admin/props/{{prop._id}}/edit/">Edit</a>)
-        </li>
-    </ul>
-{{/each}}
+{{#if user.isAdmin}}
+  <a href="admin/props/new">Create new Proposition</a>
+  {{#each props as |prop|}}
+      <ul>
+          <li>
+              {{prop.name}} (<a href="/admin/props/{{prop._id}}/edit/">Edit</a>)
+          </li>
+      </ul>
+  {{/each}}
+{{else}}
+  You must be an admin to view this page.
+  {{#if user}}
+    You are logged in with: {{user.email}}
+  {{/if}}
+{{/if}}

--- a/views/partials/navbar.hbs
+++ b/views/partials/navbar.hbs
@@ -9,7 +9,7 @@
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="nav navbar-nav ml-auto">
-      <li><a href="/admin" class="btn btn-link">Admin</a></li>
+      {{#if user.isAdmin}}<li><a href="/admin" class="btn btn-link">Admin</a></li>{{/if}}
       {{# if user}}
         <li><a href="/logout" class="btn btn-link">Log Out</a></li>
       {{else}}

--- a/views/props/edit.hbs
+++ b/views/props/edit.hbs
@@ -1,0 +1,36 @@
+<div class="container">
+  <form action="/admin/props/{{prop.id}}" method="post" class="center_div">
+    <h1>Edit Proposition</h1>
+    <div class="form-group">
+      <label for="prop-name">Proposition Name</label><span class="required-star">*</span>
+      <input type="text" name="name" class="form-control" id="prop-name" placeholder="ex: Proposition 1 or Proposition E" value="{{prop.name}}" required>
+    </div>
+    <div class="form-group">
+      <label for=prop-summary"">Summary</label><span class="required-star">*</span>
+      <input type="text" name="summary" class="form-control" id="prop-summary" placeholder="Briefly explain what the proposition is about" value="{{prop.summary}}" required>
+    </div>
+    {{#each prop.pros as |pro|}}
+      <div class="form-group">
+        <label for="prop-pros">Pros</label><span class="required-star"></span>
+        <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?" value="{{pro}}">
+      </div>
+    {{/each}}
+    {{#each prop.cons as |con|}}
+    <div class="form-group">
+      <label for="prop-cons">Cons</label><span class="required-star"></span>
+      <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?" value="{{con}}">
+    </div>
+    {{/each}}
+    <div class="form-group">
+      <label for="prop-read-more-url">Read More URL</label><span class="required-star">*</span>
+      <input type="text" name="readMoreUrl" class="form-control" id="prop-read-more-url" placeholder="Where can I read more about this prop?" value="{{prop.readMoreUrl}}" required>
+    </div>
+    <div class="form-group">
+      <label for="prop-area">Who votes on this? (Enter 'California' or 'San Francisco')</label><span class="required-star">*</span>
+      <input type="text" name="area" class="form-control" id="prop-area" placeholder="'California' or 'San Francisco'" value="{{prop.area}}" required>
+    </div>
+    <div class="text-left">
+      <button type="submit" class="btn btn-dark">Update</button>
+    </div>
+  </form>
+</div>

--- a/views/props/edit.hbs
+++ b/views/props/edit.hbs
@@ -1,36 +1,43 @@
-<div class="container">
-  <form action="/admin/props/{{prop.id}}" method="post" class="center_div">
-    <h1>Edit Proposition</h1>
-    <div class="form-group">
-      <label for="prop-name">Proposition Name</label><span class="required-star">*</span>
-      <input type="text" name="name" class="form-control" id="prop-name" placeholder="ex: Proposition 1 or Proposition E" value="{{prop.name}}" required>
-    </div>
-    <div class="form-group">
-      <label for=prop-summary"">Summary</label><span class="required-star">*</span>
-      <input type="text" name="summary" class="form-control" id="prop-summary" placeholder="Briefly explain what the proposition is about" value="{{prop.summary}}" required>
-    </div>
-    {{#each prop.pros as |pro|}}
+{{#if user.isAdmin}}
+  <div class="container">
+    <form action="/admin/props/{{prop.id}}" method="post" class="center_div">
+      <h1>Edit Proposition</h1>
       <div class="form-group">
-        <label for="prop-pros">Pros</label><span class="required-star"></span>
-        <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?" value="{{pro}}">
+        <label for="prop-name">Proposition Name</label><span class="required-star">*</span>
+        <input type="text" name="name" class="form-control" id="prop-name" placeholder="ex: Proposition 1 or Proposition E" value="{{prop.name}}" required>
       </div>
-    {{/each}}
-    {{#each prop.cons as |con|}}
-    <div class="form-group">
-      <label for="prop-cons">Cons</label><span class="required-star"></span>
-      <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?" value="{{con}}">
-    </div>
-    {{/each}}
-    <div class="form-group">
-      <label for="prop-read-more-url">Read More URL</label><span class="required-star">*</span>
-      <input type="text" name="readMoreUrl" class="form-control" id="prop-read-more-url" placeholder="Where can I read more about this prop?" value="{{prop.readMoreUrl}}" required>
-    </div>
-    <div class="form-group">
-      <label for="prop-area">Who votes on this? (Enter 'California' or 'San Francisco')</label><span class="required-star">*</span>
-      <input type="text" name="area" class="form-control" id="prop-area" placeholder="'California' or 'San Francisco'" value="{{prop.area}}" required>
-    </div>
-    <div class="text-left">
-      <button type="submit" class="btn btn-dark">Update</button>
-    </div>
-  </form>
-</div>
+      <div class="form-group">
+        <label for=prop-summary"">Summary</label><span class="required-star">*</span>
+        <input type="text" name="summary" class="form-control" id="prop-summary" placeholder="Briefly explain what the proposition is about" value="{{prop.summary}}" required>
+      </div>
+      {{#each prop.pros as |pro|}}
+        <div class="form-group">
+          <label for="prop-pros">Pros</label><span class="required-star"></span>
+          <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?" value="{{pro}}">
+        </div>
+      {{/each}}
+      {{#each prop.cons as |con|}}
+      <div class="form-group">
+        <label for="prop-cons">Cons</label><span class="required-star"></span>
+        <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?" value="{{con}}">
+      </div>
+      {{/each}}
+      <div class="form-group">
+        <label for="prop-read-more-url">Read More URL</label><span class="required-star">*</span>
+        <input type="text" name="readMoreUrl" class="form-control" id="prop-read-more-url" placeholder="Where can I read more about this prop?" value="{{prop.readMoreUrl}}" required>
+      </div>
+      <div class="form-group">
+        <label for="prop-area">Who votes on this? (Enter 'California' or 'San Francisco')</label><span class="required-star">*</span>
+        <input type="text" name="area" class="form-control" id="prop-area" placeholder="'California' or 'San Francisco'" value="{{prop.area}}" required>
+      </div>
+      <div class="text-left">
+        <button type="submit" class="btn btn-dark">Update</button>
+      </div>
+    </form>
+  </div>
+{{else}}
+  You must be an admin to view this page.
+  {{#if user}}
+    You are logged in with: {{user.email}}
+  {{/if}}
+{{/if}}

--- a/views/props/new.hbs
+++ b/views/props/new.hbs
@@ -1,64 +1,71 @@
-<div class="container">
-  <form action="/admin/props" method="post" class="center_div">
-    <h1>New Proposition</h1>
-    <div class="form-group">
-      <label for="prop-name">Proposition Name</label><span class="required-star">*</span>
-      <input type="text" name="name" class="form-control" id="prop-name" placeholder="ex: Proposition 1 or Proposition E" required>
-    </div>
-    <div class="form-group">
-      <label for="prop-summary">Summary</label><span class="required-star">*</span>
-      <input type="text" name="summary" class="form-control" id="prop-summary" placeholder="Briefly explain what the proposition is about" required>
-    </div>
-    <div class="form-group">
-      <label for="prop-pros">Pros #1</label><span class="required-star">*</span>
-      <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?" required>
-    </div>
-    <div class="form-group">
-      <label for="prop-pros">Pros #2</label><span class="required-star">*</span>
-      <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?" required>
-    </div>
-    <div class="form-group">
-      <label for="prop-pros">Pros #3</label>
-      <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?">
-    </div>
-    <div class="form-group">
-      <label for="prop-pros">Pros #4</label>
-      <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?">
-    </div>
+{{#if user.isAdmin}}
+  <div class="container">
+    <form action="/admin/props" method="post" class="center_div">
+      <h1>New Proposition</h1>
       <div class="form-group">
-      <label for="prop-pros">Pros #5</label>
-      <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?">
-    </div>
-    <div class="form-group">
-      <label for="prop-cons">Cons #1</label><span class="required-star">*</span>
-      <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?" required>
-    </div>
-    <div class="form-group">
-      <label for="prop-cons">Cons #2</label><span class="required-star">*</span>
-      <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?" required>
-    </div>
-    <div class="form-group">
-      <label for="prop-cons">Cons #3</label>
-      <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?">
-    </div>
-    <div class="form-group">
-      <label for="prop-cons">Cons #4</label>
-      <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?">
-    </div>
-    <div class="form-group">
-      <label for="prop-cons">Cons #5</label>
-      <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?">
-    </div>
-    <div class="form-group">
-      <label for="prop-read-more-url">Read More URL</label><span class="required-star">*</span>
-      <input type="text" name="readMoreUrl" class="form-control" id="prop-read-more-url" placeholder="Where can I read more about this prop?" required>
-    </div>
-    <div class="form-group">
-      <label for="prop-area">Who votes on this? (Enter 'California' or 'San Francisco')</label><span class="required-star">*</span>
-      <input type="text" name="area" class="form-control" id="prop-area" placeholder="'California' or 'San Francisco'" required>
-    </div>
-    <div class="text-left">
-      <button type="submit" class="btn btn-dark">Create</button>
-    </div>
-  </form>
-</div>
+        <label for="prop-name">Proposition Name</label><span class="required-star">*</span>
+        <input type="text" name="name" class="form-control" id="prop-name" placeholder="ex: Proposition 1 or Proposition E" required>
+      </div>
+      <div class="form-group">
+        <label for="prop-summary">Summary</label><span class="required-star">*</span>
+        <input type="text" name="summary" class="form-control" id="prop-summary" placeholder="Briefly explain what the proposition is about" required>
+      </div>
+      <div class="form-group">
+        <label for="prop-pros">Pros #1</label><span class="required-star">*</span>
+        <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?" required>
+      </div>
+      <div class="form-group">
+        <label for="prop-pros">Pros #2</label><span class="required-star">*</span>
+        <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?" required>
+      </div>
+      <div class="form-group">
+        <label for="prop-pros">Pros #3</label>
+        <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?">
+      </div>
+      <div class="form-group">
+        <label for="prop-pros">Pros #4</label>
+        <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?">
+      </div>
+        <div class="form-group">
+        <label for="prop-pros">Pros #5</label>
+        <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?">
+      </div>
+      <div class="form-group">
+        <label for="prop-cons">Cons #1</label><span class="required-star">*</span>
+        <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?" required>
+      </div>
+      <div class="form-group">
+        <label for="prop-cons">Cons #2</label><span class="required-star">*</span>
+        <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?" required>
+      </div>
+      <div class="form-group">
+        <label for="prop-cons">Cons #3</label>
+        <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?">
+      </div>
+      <div class="form-group">
+        <label for="prop-cons">Cons #4</label>
+        <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?">
+      </div>
+      <div class="form-group">
+        <label for="prop-cons">Cons #5</label>
+        <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?">
+      </div>
+      <div class="form-group">
+        <label for="prop-read-more-url">Read More URL</label><span class="required-star">*</span>
+        <input type="text" name="readMoreUrl" class="form-control" id="prop-read-more-url" placeholder="Where can I read more about this prop?" required>
+      </div>
+      <div class="form-group">
+        <label for="prop-area">Who votes on this? (Enter 'California' or 'San Francisco')</label><span class="required-star">*</span>
+        <input type="text" name="area" class="form-control" id="prop-area" placeholder="'California' or 'San Francisco'" required>
+      </div>
+      <div class="text-left">
+        <button type="submit" class="btn btn-dark">Create</button>
+      </div>
+    </form>
+  </div>
+  {{else}}
+    You must be an admin to view this page.
+    {{#if user}}
+      You are logged in with: {{user.email}}
+    {{/if}}
+  {{/if}}

--- a/views/props/new.hbs
+++ b/views/props/new.hbs
@@ -2,59 +2,59 @@
   <form action="/admin/props" method="post" class="center_div">
     <h1>New Proposition</h1>
     <div class="form-group">
-      <label for="event-title">Proposition Name</label><span class="required-star">*</span>
+      <label for="prop-name">Proposition Name</label><span class="required-star">*</span>
       <input type="text" name="name" class="form-control" id="prop-name" placeholder="ex: Proposition 1 or Proposition E" required>
     </div>
     <div class="form-group">
-      <label for="event-title">Summary</label><span class="required-star">*</span>
+      <label for="prop-summary">Summary</label><span class="required-star">*</span>
       <input type="text" name="summary" class="form-control" id="prop-summary" placeholder="Briefly explain what the proposition is about" required>
     </div>
     <div class="form-group">
-      <label for="event-title">Pros #1</label><span class="required-star">*</span>
+      <label for="prop-pros">Pros #1</label><span class="required-star">*</span>
       <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?" required>
     </div>
     <div class="form-group">
-      <label for="event-title">Pros #2</label><span class="required-star">*</span>
+      <label for="prop-pros">Pros #2</label><span class="required-star">*</span>
       <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?" required>
     </div>
     <div class="form-group">
-      <label for="event-title">Pros #3</label>
+      <label for="prop-pros">Pros #3</label>
       <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?">
     </div>
     <div class="form-group">
-      <label for="event-title">Pros #4</label>
+      <label for="prop-pros">Pros #4</label>
       <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?">
     </div>
       <div class="form-group">
-      <label for="event-title">Pros #5</label>
+      <label for="prop-pros">Pros #5</label>
       <input type="text" name="pros" class="form-control" id="prop-pros" placeholder="What do proponents say about it?">
     </div>
     <div class="form-group">
-      <label for="event-title">Cons #1</label><span class="required-star">*</span>
+      <label for="prop-cons">Cons #1</label><span class="required-star">*</span>
       <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?" required>
     </div>
     <div class="form-group">
-      <label for="event-title">Cons #2</label><span class="required-star">*</span>
+      <label for="prop-cons">Cons #2</label><span class="required-star">*</span>
       <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?" required>
     </div>
     <div class="form-group">
-      <label for="event-title">Cons #3</label>
+      <label for="prop-cons">Cons #3</label>
       <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?">
     </div>
     <div class="form-group">
-      <label for="event-title">Cons #4</label>
+      <label for="prop-cons">Cons #4</label>
       <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?">
     </div>
     <div class="form-group">
-      <label for="event-title">Cons #5</label>
+      <label for="prop-cons">Cons #5</label>
       <input type="text" name="cons" class="form-control" id="prop-cons" placeholder="What do people against this proposition say?">
     </div>
     <div class="form-group">
-      <label for="event-title">Read More URL</label><span class="required-star">*</span>
+      <label for="prop-read-more-url">Read More URL</label><span class="required-star">*</span>
       <input type="text" name="readMoreUrl" class="form-control" id="prop-read-more-url" placeholder="Where can I read more about this prop?" required>
     </div>
     <div class="form-group">
-      <label for="event-title">Who votes on this?</label><span class="required-star">*</span>
+      <label for="prop-area">Who votes on this? (Enter 'California' or 'San Francisco')</label><span class="required-star">*</span>
       <input type="text" name="area" class="form-control" id="prop-area" placeholder="'California' or 'San Francisco'" required>
     </div>
     <div class="text-left">

--- a/views/users/login.hbs
+++ b/views/users/login.hbs
@@ -2,7 +2,6 @@
   <form action="/login" method="post" class="center_div">
     <h1>Log In</h1>
     <p class="helper-text">You must log in to save your votes</p>
-    {{# if reasonForLogin}}<p>{{reasonForLogin}}</p>{{/if}}
 
     <div class="form-group">
       <label for="user-email" style="display:none">Email</label>


### PR DESCRIPTION
(1) look up users by codename using /friend/{{codename}}
For ex, try http://localhost:3000/friend/nicolai-safai once you've merged changes

It is not currently concerned whether user has elected to make their profile public, but this should be quick to add and can even be done from the frontend with something like ``{{#if user.profilePublic}}show index as normal{{else}}This user has chosen to hide their profile{{/if}}``

(2) You can update props on /admin

(3) Only admins can view pages at /admin/ -- currently protected from the .hbs side, but we should eventually add an admin.js router file and protect the whole route from the controller side instead.

To make yourself an admin:
- go to mLab users: https://mlab.com/databases/votersguide/collections/users
- find your user
- Then click "edit"
-  add: 
``"isAdmin": true,``
- click "save and go back"